### PR TITLE
don't show preference summaries in search results

### DIFF
--- a/src/com/android/settings/intelligence/search/SearchViewHolder.java
+++ b/src/com/android/settings/intelligence/search/SearchViewHolder.java
@@ -62,15 +62,7 @@ public abstract class SearchViewHolder extends RecyclerView.ViewHolder {
 
     public void onBind(SearchFragment fragment, SearchResult result) {
         titleView.setText(result.title);
-        // TODO (b/36101902) remove check for DYNAMIC_PLACEHOLDER
-        if (TextUtils.isEmpty(result.summary)
-                || TextUtils.equals(result.summary, mPlaceholderSummary)
-                || TextUtils.equals(result.summary, DYNAMIC_PLACEHOLDER)) {
-            summaryView.setVisibility(View.GONE);
-        } else {
-            summaryView.setText(result.summary);
-            summaryView.setVisibility(View.VISIBLE);
-        }
+        summaryView.setVisibility(View.GONE);
 
         if (result instanceof AppSearchResult) {
             AppSearchResult appResult = (AppSearchResult) result;


### PR DESCRIPTION
Some preference summaries depend on dynamic string formatting that is performed by Settings app when it loads them.

SettingsIntelligenceGoogle on stock Pixel OS doesn't show preference summaries.

Resolves https://github.com/GrapheneOS/os-issue-tracker/issues/4705